### PR TITLE
Pass BP object to `compute_zai` to dispatch not only on message type but model as well

### DIFF
--- a/src/Models/ising.jl
+++ b/src/Models/ising.jl
@@ -179,7 +179,7 @@ function BeliefPropagation.compute_za(ψₐ::IsingCoupling, msg_in::AbstractVect
     return cosh(Jₐ) * (1 + prodtanh)
 end
 
-function BeliefPropagation.compute_zai(uai::Real, hia::Real)
+function BeliefPropagation.compute_zai(bp::BPIsing, uai::Real, hia::Real)
     return (1 + tanh(uai)*tanh(hia)) / 2
 end
 
@@ -190,7 +190,6 @@ function BeliefPropagation.update_v_ms!(bp::BPIsing,
     hᵢ = ϕ[i].βh + b[i]*rein
     bnew[i] = @views cavity!(hnew[ei], u[ei], +, hᵢ)
     errb = abs(bnew[i] - b[i])
-    # logzᵢ = abs(bnew[i]) - sum(abs, u[ei]; init=zero(eltype(bp)))
     b[i] = bnew[i]
     errv = -Inf
     for ia in ei
@@ -206,9 +205,8 @@ function BeliefPropagation.update_f_ms!(bp::BPIsing, a::Integer,
     ea = edge_indices(g, factor(a))
     Jₐ = ψ[a].βJ
     @views minh = cavity!(unew[ea], abs.(h[ea]), min, convert(eltype(h), abs(Jₐ)))
-    signs, prodsigns = cavity(sign.(h[ea]), *, sign(Jₐ))
+    signs, = cavity(sign.(h[ea]), *, sign(Jₐ))
     unew[ea] .= signs .* unew[ea]
-    # logzₐ = abs(Jₐ) - 2min(abs(Jₐ), minh)*(prodsigns!=1)
     err = -Inf
     for ai in ea
         err = max(err, abs(unew[ai] - u[ai]))

--- a/src/bp.jl
+++ b/src/bp.jl
@@ -204,7 +204,8 @@ function compute_za(ψₐ::BPFactor, msg_in::AbstractVector{<:AbstractVector{<:R
         for xₐ in Iterators.product(eachindex.(msg_in)...))
 end
 
-function compute_zai(uai::AbstractVector{<:Real}, hia::AbstractVector{<:Real})
+function compute_zai(bp::BP, uai::AbstractVector{<:Real}, 
+        hia::AbstractVector{<:Real})
     return sum(uaix * hiax for(uaix, hiax) in zip(uai, hia))
 end
 
@@ -228,7 +229,7 @@ function bethe_free_energy_bp(bp::BP)
     end
 
     for ai in edge_indices(g)
-        zₐᵢ = compute_zai(u[ai], h[ai])
+        zₐᵢ = compute_zai(bp, u[ai], h[ai])
         f_edges += -log(zₐᵢ)
     end
 


### PR DESCRIPTION
Because different models could handle messages with different parametrizations, albeit with the same type for messages