### PR TITLE
Reorganize callbacks and convergence checkers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BeliefPropagation"
 uuid = "f47dce41-c8ad-4b69-b8b4-f2a36c7ebdf8"
 authors = ["stecrotti <stefano.crotti@polito.it>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/BeliefPropagation.jl
+++ b/src/BeliefPropagation.jl
@@ -21,7 +21,7 @@ include("Test/Test.jl")
 export BPFactor, TabulatedBPFactor, UniformFactor
 export BP, reset!, randomize!, nstates, evaluate, energy, energy_factors, energy_variables
 export iterate!, beliefs, factor_beliefs, avg_energy, bethe_free_energy
-export MessageConvergence, belief_convergence, ProgressCallback
+export MessageConvergence, BeliefConvergence, ProgressAndConvergence
 export update_f_bp!, update_v_bp!, beliefs_bp, factor_beliefs_bp, avg_energy_bp
 export update_f_ms!, update_v_ms!, beliefs_ms, factor_beliefs_ms, iterate_ms!,
     avg_energy_ms, bethe_free_energy_ms

--- a/test/bp.jl
+++ b/test/bp.jl
@@ -92,7 +92,8 @@ end
     g = rand_tree_factor_graph(n)
     qs = rand(rng, 2:4, nvariables(g))
     bp = rand_bp(rng, g, qs)
-    iterate!(bp; maxiter=100, check_convergence=belief_convergence(1e-12))
+    cb = ProgressAndConvergence(100, 0.0, BeliefConvergence())
+    iterate!(bp; callbacks = [cb])
     b = beliefs(bp)
     test_observables_bp(bp)
 end


### PR DESCRIPTION
Formalize callbacks a little more, rewrite the check for convergence to a fixed point as a callback