### PR TITLE
A few optimizations

### DIFF
--- a/src/Models/ksat.jl
+++ b/src/Models/ksat.jl
@@ -90,7 +90,7 @@ function BeliefPropagation.set_messages_variable!(bp::BPKSAT, ei, i, hnew, bnew,
         if zᵢ != 0
             hnew[ia] = hnew[ia] ./ zᵢ₂ₐ
         end
-        errv = max(errv, maximum(abs, hnew[ia] .- h[ia]))
+        errv = max(errv, abs(h[ia][1] - hnew[ia][1]))
         h[ia] = damp!(h[ia], hnew[ia], damp)
     end
     return errv, errb
@@ -111,7 +111,7 @@ function BeliefPropagation.set_messages_factor!(bp::BPKSAT, ea, unew, damp)
     err = zero(eltype(bp))
     for ai in ea
         unew[ai] = unew[ai] ./ sum(unew[ai])
-        err = max(err, maximum(abs, unew[ai] .- u[ai]))
+        err = max(err, abs(unew[ai][1] - u[ai][1]))
         u[ai] = damp!(u[ai], unew[ai], damp)
     end
     return err

--- a/src/Models/ksat.jl
+++ b/src/Models/ksat.jl
@@ -81,10 +81,10 @@ function BeliefPropagation.set_messages_variable!(bp::BPKSAT, ei, i, hnew, bnew,
     if zᵢ != 0
         bnew[i] = bnew[i] ./ zᵢ
     end
-    errb = maximum(abs, bnew[i] .- b[i])
+    errb = abs(bnew[i][1] - b[i][1])
     b[i] = bnew[i]
     errv = zero(eltype(bp))
-    for ia in ei
+    @inbounds for ia in ei
         zᵢ₂ₐ = sum(hnew[ia])
         # there can be cases where hnew[i] is all zeros -> do not normalize
         if zᵢ != 0
@@ -128,9 +128,9 @@ function BeliefPropagation.update_f_bp!(bp::BPKSAT, a::Integer, unew, damp::Real
         htemp *= h[ia][Jα+1]
     end
     htemp = one(eltype(bp))
-    @inbounds for (α, ia) in Iterators.reverse(enumerate(ea))
+    @inbounds for (Jα, ia) in Iterators.reverse(zip(Jₐ, ea))
         unew[ia] = unew[ia] .* (htemp, htemp)
-        htemp *= h[ia][Jₐ[α]+1]
+        htemp *= h[ia][Jα+1]
     end
     @inbounds for (α, ia) in enumerate(ea)
         prodh = unew[ia][1]

--- a/src/bp.jl
+++ b/src/bp.jl
@@ -376,7 +376,7 @@ end
 
 function (cb::ProgressAndConvergence)(bp, errv, errf, errb, it)
     ε = cb.conv_checker(bp, errv, errf, errb, it) |> value
-    next!(cb.prog, showvalues=[(:it, "$it/$(cb.prog.n)"), (:ε, "$ε/$(cb.tol)")])
+    next!(cb.prog, showvalues=[(:it, :($it/$(cb.prog.n))), (:ε, :($ε/$(cb.tol)))])
     cb.iters = it
     converged = ε < cb.tol
     cb.converged = converged

--- a/src/bp.jl
+++ b/src/bp.jl
@@ -440,8 +440,7 @@ function damp!(x::T, xnew::T, damp::Real) where {T<:Union{<:AbstractVector,<:Tup
             xinew = xinew * (1-damp) + xi * damp
         end
     end
-    x, xnew = xnew, x
-    return x
+    return xnew
 end
 
 function set_messages_variable!(bp, ei, i, hnew, bnew, damp)


### PR DESCRIPTION
Improvements:
- Avoid allocating strings in progress bar
- Speed-up in computation of convergence error for specialized kSAT implementation


Benchmark:

## Job Properties
* Time of benchmarks:
    - Target: 8 Jan 2025 - 14:24
    - Baseline: 8 Jan 2025 - 14:26
* Package commits:
    - Target: 05a08f
    - Baseline: dbdf8b
* Julia commits:
    - Target: 5e9a32
    - Baseline: 5e9a32
* Julia command flags:
    - Target: None
    - Baseline: None
* Environment variables:
    - Target: None
    - Baseline: None

## Results
A ratio greater than `1.0` denotes a possible regression (marked with :x:), while a ratio less
than `1.0` denotes a possible improvement (marked with :white_check_mark:). All results are shown below.

| ID                             | time ratio                   | memory ratio                 |
|--------------------------------|------------------------------|------------------------------|
| `["generic bp", "run bp"]`     |                   0.98 (5%)  | 0.99 (1%) :white_check_mark: |
| `["generic bp", "run maxsum"]` |                   0.97 (5%)  |                   1.00 (1%)  |
| `["ising", "run bp"]`          | 0.94 (5%) :white_check_mark: | 0.83 (1%) :white_check_mark: |
| `["ising", "run maxsum"]`      | 0.87 (5%) :white_check_mark: | 0.90 (1%) :white_check_mark: |
| `["ksat", "generic"]`          |                   1.00 (5%)  |                   1.00 (1%)  |
| `["ksat", "optimized"]`        | 0.84 (5%) :white_check_mark: | 0.67 (1%) :white_check_mark: |
```